### PR TITLE
Added a batch file and a Nuget Package Specification to automate the process of building NuGet packages for loggly-csharp

### DIFF
--- a/loggly-csharp.sln
+++ b/loggly-csharp.sln
@@ -8,6 +8,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "stuff", "stuff", "{5B1BDA21-CAE4-4686-B45B-1087AA9A36F4}"
 	ProjectSection(SolutionItems) = preProject
 		license.txt = license.txt
+		loggly.nuspec = loggly.nuspec
+		package.cmd = package.cmd
 		readme.textile = readme.textile
 	EndProjectSection
 EndProject

--- a/loggly.nuspec
+++ b/loggly.nuspec
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata>
+    <id>loggly-csharp</id>
+    <version>1.0</version>
+    <authors>Karl Seguin</authors>
+    <owners>Karl Seguin</owners>
+    <description>A .NET driver for loggly.com</description>
+    <language>en-US</language>
+    <projectUrl>https://github.com/karlseguin/loggly-csharp</projectUrl>
+    <licenseUrl>https://github.com/karlseguin/loggly-csharp/blob/master/license.txt</licenseUrl>
+    <dependencies>
+      <dependency id="Newtonsoft.Json" version="3.5.0" />
+    </dependencies>
+    <tags>LOGS LOGGING NLOG LOGGLY</tags>
+  </metadata>
+</package>

--- a/package.cmd
+++ b/package.cmd
@@ -1,0 +1,12 @@
+if not exist Download mkdir Download
+if not exist Download\package mkdir Download\package
+if not exist Download\package\lib mkdir Download\package\lib
+if not exist Download\package\lib\net4 mkdir Download\package\lib\net4
+
+tools\ilmerge.exe /lib:loggly-csharp\bin\Release /internalize /ndebug /v2 /out:Download\Loggly.dll Loggly.dll Newtonsoft.Json.dll
+
+copy LICENSE.txt Download
+
+copy loggly-csharp\bin\Release\Loggly.dll Download\Package\lib\net4\
+
+nuget.exe pack loggly.nuspec -b Download\Package -o Download


### PR DESCRIPTION
Added a batch file and a Nuget Package specification (.nuspec) that will allow anyone who wants to put loggly-csharp onto NuGet to automate the process of building a NuGet package.

I'm starting to take a look at loggly and wanted the CSharp drivers on NuGet :)
