### PR TITLE
Fixed client issues when logging failing

### DIFF
--- a/loggly-csharp.tests/LogTests.cs
+++ b/loggly-csharp.tests/LogTests.cs
@@ -60,5 +60,27 @@ namespace Loggly.Tests.LoggerTests
 
          WaitOne();
       }
+
+      [Test]
+      public void ReturnsSuccessResponse()
+      {
+         Server.Stub(new ApiExpectation {Response = "{eventstamp: 123495}"});
+         Assert.True(new Logger("ITS-OVER-9000").LogSync("Vegeta!!!").Success);
+      }
+
+      [Test]
+      public void ReturnsErrorResponse()
+      {
+         // Missing expectation causing the error
+         Assert.False(new Logger("ITS-OVER-9000").LogSync("Vegeta!!!").Success);
+      }
+
+      [Test]
+      public void ReturnsErrorResponseWhenNetworkIssues()
+      {
+         // There is no listener on that port
+         LogglyConfiguration.Configure(c => c.ForceUrlTo("http://localhost:9949/"));
+         Assert.False(new Logger("ITS-OVER-9000").LogSync("Vegeta!!!").Success);
+      }
    }
 }

--- a/loggly-csharp/Logger.cs
+++ b/loggly-csharp/Logger.cs
@@ -123,7 +123,14 @@ namespace Loggly
          {
             if (r.Success)
             {
-               callback(JsonConvert.DeserializeObject<LogResponse>(r.Raw));
+               var res = JsonConvert.DeserializeObject<LogResponse>(r.Raw);
+               res.Success = true;
+               callback(res);
+            }
+            else
+            {
+               var res = new LogResponse{ Success = false };
+               callback(res);
             }
          };
          communicator.SendPayload(Communicator.POST, string.Concat("inputs/", _inputKey), message, json, callbackWrapper);

--- a/loggly-csharp/Responses/LogResponse.cs
+++ b/loggly-csharp/Responses/LogResponse.cs
@@ -6,5 +6,6 @@ namespace Loggly.Responses
    {
       [JsonProperty("eventstamp")]
       public int TimeStamp { get; set; }
+      public bool Success { get; set; }
    }
 }


### PR DESCRIPTION
1. When you call LogSync method and Loggly server returns an error (i.e.
   http status code 500), the calling code will be hanging because callback
   function will be never called (see Logger class changes). The main idea
   was to add the logging status to the LogResponse class and to assume
   that callback must be called in any case.
2. When you call LogSync method and Loggly server is unavailable due to
   some network issues, the callback function won't be called as well (see
   above). See Communicator class fix for that
