### PR TITLE
Fix Nuget package build

### DIFF
--- a/loggly.nuspec
+++ b/loggly.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>loggly-csharp</id>
-        <version>2.2</version>
+        <version>2.3</version>
         <authors>Karl Seguin</authors>
         <owners>Karl Seguin</owners>
         <licenseUrl>https://github.com/karlseguin/loggly-csharp/blob/master/license.txt</licenseUrl>
@@ -13,7 +13,6 @@
         <tags>LOGS LOGGING NLOG LOGGLY</tags>
         <dependencies>
             <dependency id="Newtonsoft.Json" version="5.0.0" />
-            <dependency id="NUnit" version="2.6.2" />
         </dependencies>
     </metadata>
 </package>

--- a/package.cmd
+++ b/package.cmd
@@ -3,10 +3,6 @@ if not exist Download\package mkdir Download\package
 if not exist Download\package\lib mkdir Download\package\lib
 if not exist Download\package\lib\net35 mkdir Download\package\lib\net35
 
-ilmerge.exe /lib:loggly-csharp\bin\Release /internalize /ndebug /v2 /out:Download\Loggly.dll Loggly.dll Newtonsoft.Json.dll
-
-copy LICENSE.txt Download
-
 copy loggly-csharp\bin\Release\Loggly.dll Download\Package\lib\net35\
 
 nuget.exe pack loggly.nuspec -BasePath Download\Package -o Download


### PR DESCRIPTION
Various issues fixed and released v.2.3
1. Removed NUnit dependency from the package spec
2. Removed ILMerge call that merged Loggly.dll wit Newtonsoft.Json. Now we
   have this lib referencing as a dependency.
