### PR TITLE
Update to loggly-csharp library

### DIFF
--- a/loggly-csharp/Logger.cs
+++ b/loggly-csharp/Logger.cs
@@ -13,12 +13,9 @@ namespace Loggly
       private readonly string _inputKey;
       
       public Logger(string inputKey,
-          string applicationName)
-      {
-          _inputKey = inputKey;
-          _applicationName = applicationName;
-      }
-
+          string applicationName) 
+          : this(inputKey,null,applicationName){}
+      
       public Logger(string inputKey, 
           string alternativeUrl = null,
           string applicationName = null )


### PR DESCRIPTION
Added few more fields like applicationName, userAgent as a part of the library to easily identify the application and the type of library used to send logs to Loggly. Set "userAgent" as "loggly-csharp". Application Name is optional. Its default value will be "loggly-csharp-app". Added one more constructor in order to not to force users to pass null as a value if they want to pass "applicationName". Fully backward compatible. Also updated the default value of the URL
