### PR TITLE
Support to send X-Forwarded-For Http Header

### DIFF
--- a/source/Loggly/Transports/HttpTransports/HttpMessageTransport.cs
+++ b/source/Loggly/Transports/HttpTransports/HttpMessageTransport.cs
@@ -62,6 +62,8 @@ namespace Loggly
         {
             var httpWebRequest = CreateHttpWebRequest(Url, HttpRequestType.Post);
 
+            httpWebRequest.Headers.Add("X-Forwarded-For", Utils.NetworkUtils.GetHostIPAddress());
+
             if (!string.IsNullOrEmpty(RenderedTags))
             {
                 httpWebRequest.Headers.Add("X-LOGGLY-TAG", RenderedTags);

--- a/source/Loggly/Utils/NetworkUtils.cs
+++ b/source/Loggly/Utils/NetworkUtils.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Loggly.Utils
+{
+    public class NetworkUtils
+    {
+        #region host information
+        public static string GetHostIPAddress()
+        {
+            var addressess = Dns.GetHostAddresses(Environment.MachineName);
+            foreach (var addrs in addressess)
+            {
+                if (addrs.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
+                {
+                    return addrs.ToString();
+                }
+            }
+
+            //If no IP Address is found then return machine name
+            return Environment.MachineName;
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
Loggly now parses Http Headers like content-type, x-forwarded-for. Adding support to the Latter one.
