### PR TITLE
Adding support for NTLM authenticating proxy servers

### DIFF
--- a/source/Loggly/Transports/HttpTransports/HttpTransportBase.cs
+++ b/source/Loggly/Transports/HttpTransports/HttpTransportBase.cs
@@ -17,7 +17,16 @@ namespace Loggly
         }
         protected HttpWebRequest CreateHttpWebRequest(string url, HttpRequestType requestType)
         {
+            return CreateHttpWebRequest(url, requestType, false);
+        }
+        protected HttpWebRequest CreateHttpWebRequest(string url, HttpRequestType requestType, bool useProxy)
+        {
             var request = (HttpWebRequest)WebRequest.Create(url);
+            
+            if (useProxy)
+            {
+                request.Proxy.Credentials = System.Net.CredentialCache.DefaultCredentials;
+            }
             request.Method = requestType.ToString().ToUpper();
             request.UserAgent = _userAgent;
             request.KeepAlive = false;


### PR DESCRIPTION
We have a http proxy at work that requires NTLM authentication. I've re-factored the http transport code to retry with the UseDefaultCredentials property set to True if the default WebRequest call fails with a proxy authentication error.