### PR TITLE
Add TypeNameHandling = TypeNameHandling.None to ToJson

### DIFF
--- a/source/Loggly/LogglyClient.cs
+++ b/source/Loggly/LogglyClient.cs
@@ -58,7 +58,11 @@ namespace Loggly
 
         private static string ToJson(object value)
         {
-            return JsonConvert.SerializeObject(value, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+            return JsonConvert.SerializeObject(value, new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore,
+                TypeNameHandling = TypeNameHandling.None,
+            });
         }
         
         private IMessageTransport TransportFactory()


### PR DESCRIPTION
The settings provided to SerializeObject are merged with those in JsonConvert.DefaultSettings, so make sure to override TypeNameHandling because Loggly goes bananas when $type keys exist.