### PR TITLE
Use Loggly Bulk Endpoint for multiple messages.

### DIFF
--- a/source/Loggly/Interfaces/ILogglyClient.cs
+++ b/source/Loggly/Interfaces/ILogglyClient.cs
@@ -1,12 +1,11 @@
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Loggly.Responses;
 
 namespace Loggly
 {
-   public interface ILogglyClient
-   {
-       Task<LogResponse> Log(LogglyEvent logglyEvent);
-   }
+    public interface ILogglyClient
+    {
+        Task<LogResponse> Log(LogglyEvent logglyEvent);
+        Task<LogResponse> Log(IEnumerable<LogglyEvent> logglyEvents);
+    }
 }

--- a/source/Loggly/Loggly.csproj
+++ b/source/Loggly/Loggly.csproj
@@ -37,8 +37,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.5\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/source/Loggly/Transports/HttpTransports/HttpMessageTransport.cs
+++ b/source/Loggly/Transports/HttpTransports/HttpMessageTransport.cs
@@ -11,20 +11,36 @@ namespace Loggly
 {
     internal class HttpMessageTransport : HttpTransportBase, IMessageTransport
     {
-        private static string __url;
+        private static string _urlSingle;
+        private static string _urlBulk;
 
-        private static string Url
+        private static string UrlSingle
         {
             get
             {
-                if (string.IsNullOrEmpty(__url))
+                if (string.IsNullOrEmpty(_urlSingle))
                 {
-                    __url = string.Format("https://{0}:{1}/inputs/{2}"
+                    _urlSingle = string.Format("https://{0}:{1}/inputs/{2}"
                         , LogglyConfig.Instance.Transport.EndpointHostname
                         , LogglyConfig.Instance.Transport.EndpointPort
                         , LogglyConfig.Instance.CustomerToken);
                 }
-                return __url;
+                return _urlSingle;
+            }
+        }
+
+        private static string UrlBulk
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(_urlBulk))
+                {
+                    _urlBulk = string.Format("https://{0}:{1}/bulk/{2}"
+                        , LogglyConfig.Instance.Transport.EndpointHostname
+                        , LogglyConfig.Instance.Transport.EndpointPort
+                        , LogglyConfig.Instance.CustomerToken);
+                }
+                return _urlBulk;
             }
         }
 
@@ -66,7 +82,7 @@ namespace Loggly
 
         private HttpWebRequest CreateHttpWebRequest(List<LogglyMessage> message)
         {
-            var httpWebRequest = CreateHttpWebRequest(Url, HttpRequestType.Post);
+            var httpWebRequest = CreateHttpWebRequest(message.Count == 1 ? UrlSingle : UrlBulk, HttpRequestType.Post);
 
             if (!string.IsNullOrEmpty(RenderedTags))
             {

--- a/source/Loggly/Transports/Interfaces/IMessageTransport.cs
+++ b/source/Loggly/Transports/Interfaces/IMessageTransport.cs
@@ -1,10 +1,10 @@
-using System;
-using Loggly.Responses;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Loggly
 {
     internal interface IMessageTransport
     {
-        LogResponse Send(LogglyMessage message);
+        Task<LogResponse> Send(IEnumerable<LogglyMessage> message);
     }
 }

--- a/source/Loggly/Transports/SyslogTransports/SyslogSecureTransport.cs
+++ b/source/Loggly/Transports/SyslogTransports/SyslogSecureTransport.cs
@@ -7,6 +7,7 @@ using System.Net.Security;
 using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using System.Threading.Tasks;
 using Loggly.Responses;
 
 namespace Loggly.Transports.Syslog
@@ -22,7 +23,7 @@ namespace Loggly.Transports.Syslog
             return sslPolicyErrors == SslPolicyErrors.None;
         }
 
-        protected override Stream GetNetworkStream(TcpClient client)
+        protected override async Task<Stream> GetNetworkStream(TcpClient client)
         {
             var sslStream = new SslStream(
                 client.GetStream(),
@@ -31,7 +32,7 @@ namespace Loggly.Transports.Syslog
                 null
                 );
 
-            sslStream.AuthenticateAsClient(Hostname);
+            await sslStream.AuthenticateAsClientAsync(Hostname).ConfigureAwait(false);
 
             return sslStream;
         }

--- a/source/Loggly/Transports/SyslogTransports/SyslogTcpTransport.cs
+++ b/source/Loggly/Transports/SyslogTransports/SyslogTcpTransport.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Net.Sockets;
 using System.Security.Authentication;
+using System.Threading.Tasks;
 using Loggly.Config;
 
 namespace Loggly.Transports.Syslog
@@ -17,7 +18,7 @@ namespace Loggly.Transports.Syslog
             return client.GetStream();
         }
 
-        protected override void Send(SyslogMessage syslogMessage)
+        protected override async Task Send(SyslogMessage syslogMessage)
         {
             var client = new TcpClient(Hostname, LogglyConfig.Instance.Transport.EndpointPort);
 
@@ -25,8 +26,8 @@ namespace Loggly.Transports.Syslog
             {
                 byte[] messageBytes = syslogMessage.GetBytes();
                 var networkStream = GetNetworkStream(client);
-                networkStream.Write(messageBytes, 0, messageBytes.Length);
-                networkStream.Flush();
+                await networkStream.WriteAsync(messageBytes, 0, messageBytes.Length).ConfigureAwait(false);
+                await networkStream.FlushAsync().ConfigureAwait(false);
             }
             catch (AuthenticationException e)
             {

--- a/source/Loggly/Transports/SyslogTransports/SyslogTcpTransport.cs
+++ b/source/Loggly/Transports/SyslogTransports/SyslogTcpTransport.cs
@@ -13,9 +13,9 @@ namespace Loggly.Transports.Syslog
             get { return LogglyConfig.Instance.Transport.EndpointHostname; }
         }
 
-        protected virtual Stream GetNetworkStream(TcpClient client)
+        protected virtual Task<Stream> GetNetworkStream(TcpClient client)
         {
-            return client.GetStream();
+            return Task.FromResult<Stream>(client.GetStream());
         }
 
         protected override async Task Send(SyslogMessage syslogMessage)
@@ -25,7 +25,7 @@ namespace Loggly.Transports.Syslog
             try
             {
                 byte[] messageBytes = syslogMessage.GetBytes();
-                var networkStream = GetNetworkStream(client);
+                var networkStream = await GetNetworkStream(client).ConfigureAwait(false);
                 await networkStream.WriteAsync(messageBytes, 0, messageBytes.Length).ConfigureAwait(false);
                 await networkStream.FlushAsync().ConfigureAwait(false);
             }

--- a/source/Loggly/Transports/SyslogTransports/SyslogUdpTransport.cs
+++ b/source/Loggly/Transports/SyslogTransports/SyslogUdpTransport.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Threading.Tasks;
 using Loggly.Config;
 
 namespace Loggly.Transports.Syslog
@@ -31,7 +32,7 @@ namespace Loggly.Transports.Syslog
         }
 
 
-        protected override void Send(SyslogMessage syslogMessage)
+        protected override async Task Send(SyslogMessage syslogMessage)
         {
             if (!_udpClient.IsActive)
             {
@@ -44,7 +45,7 @@ namespace Loggly.Transports.Syslog
                 if (_udpClient.IsActive)
                 {
                     var bytes = syslogMessage.GetBytes();
-                    _udpClient.Send(bytes, bytes.Length);
+                    await _udpClient.SendAsync(bytes, bytes.Length).ConfigureAwait(false);
                 }
                 else
                 {

--- a/source/Loggly/packages.config
+++ b/source/Loggly/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
We had problems sending a lot of messages so using the bulk endpoint is a requirement for me.

Added new IEnumerable overload to ILogglyClient.
All code expects an IEnumerable.
Made most things async/await.
Tested Bulk endpoint
Syslog endpoints are untested but not much changed there.

If this looks good, I'd probably want to change to use HttpClient and persist the client to leave connections open longer for better performance.