### PR TITLE
Add .NET standard support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ source/Loggly.Example/loggly.user.config
 SolutionItems/Thumbs.db
 *.nupkg
 _output/
+.vs/
+*.lock.json

--- a/SolutionItems/Properties/AssemblyInfo.cs
+++ b/SolutionItems/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Security;
 #endif
 
 [assembly: AllowPartiallyTrustedCallers]
-[assembly: AssemblyVersion("4.5.1.0")]
+[assembly: AssemblyVersion("4.6.1.0")]
 [assembly: AssemblyProduct("loggly-csharp")]
 [assembly: InternalsVisibleTo("Loggly.Tests")]
 

--- a/build.ps1
+++ b/build.ps1
@@ -41,8 +41,8 @@ function nugetPack{
         $env:PackageVersion = "1.0.0.0"
     }
 
-    nuget pack $rootFolder\Source\Loggly\Loggly.csproj -o $outputFolder -IncludeReferencedProjects -p Configuration=$configuration -Version $env:PackageVersion
-    nuget pack $rootFolder\Source\Loggly.Config\Loggly.Config.csproj -IncludeReferencedProjects -o $outputFolder -p Configuration=$configuration -Version $env:PackageVersion
+    nuget pack $rootFolder\Source\Loggly\Loggly.nuspec -o $outputFolder -IncludeReferencedProjects -p Configuration=$configuration -Version $env:PackageVersion
+    nuget pack $rootFolder\Source\Loggly.Config\Loggly.Config.nuspec -IncludeReferencedProjects -o $outputFolder -p Configuration=$configuration -Version $env:PackageVersion
 }
 
 function nugetPublish{
@@ -67,8 +67,20 @@ function buildSolution{
 function executeTests{
 
     Write-Host "Execute Tests"
-    $nunitConsole = "$rootFolder\packages\NUnit.Runners.2.6.3\tools\nunit-console.exe"
-    & $nunitConsole .\Source\Loggly.Tests\bin\$configuration\Loggly.Tests.dll
+
+    $testResultformat = ""
+    $nunitConsole = "$rootFolder\packages\NUnit.ConsoleRunner.3.4.1\tools\nunit3-console.exe"
+
+    if(Test-Path Env:\APPVEYOR){
+        $testResultformat = ";format=AppVeyor"
+        $nunitConsole = "nunit3-console"
+    }
+
+    & $nunitConsole .\Source\Loggly.Tests\bin\$configuration\Loggly.Tests.dll --result=.\Source\Loggly.Tests\bin\$configuration\nunit-results.xml$testResultformat
+
+    checkExitCode
+
+    dotnet test .\Source\NetStandard\Loggly.Tests\project.json -c $configuration --result=.\Source\NetStandard\Loggly.Tests\bin\$configuration\nunit-netstandard-results.xml
 
     checkExitCode
 }

--- a/common.ps1
+++ b/common.ps1
@@ -72,7 +72,7 @@ param(
 function _DownloadNuget{
 param([Parameter(Mandatory=$true,Position=0)]$rootPath)
 
-	$sourceNugetExe = "http://nuget.org/nuget.exe"
+	$sourceNugetExe = "https://dist.nuget.org/win-x86-commandline/v3.5.0-rc1/NuGet.exe"
 	$targetNugetExe = "$rootPath\nuget.exe"
 
 	if(!(Test-Path $targetNugetExe )){

--- a/loggly.sln
+++ b/loggly.sln
@@ -1,10 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionItems", "{5B1BDA21-CAE4-4686-B45B-1087AA9A36F4}"
 	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
 		package.cmd = package.cmd
 		readme.md = readme.md
 	EndProjectSection
@@ -23,6 +24,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{C06638
 		.nuget\NuGet.exe = .nuget\NuGet.exe
 		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NetStandard", "NetStandard", "{FF964C86-C884-453C-ACE4-41A5ACBBF2C7}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Loggly.NetStandard", "source\NetStandard\Loggly\Loggly.NetStandard.xproj", "{9E9052E5-A217-477D-8A1A-010AA7A588AF}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Loggly.Config.NetStandard", "source\NetStandard\Loggly.Config\Loggly.Config.NetStandard.xproj", "{FC9EC8AD-F2C3-4FFD-916C-2A3639DB9AE4}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Loggly.Tests.NetStandard", "source\NetStandard\Loggly.Tests\Loggly.Tests.NetStandard.xproj", "{909515FA-7AFD-4E77-907F-8E776784DF1C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -45,8 +54,25 @@ Global
 		{F66349BA-29A6-4336-BA81-993170FC9963}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F66349BA-29A6-4336-BA81-993170FC9963}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F66349BA-29A6-4336-BA81-993170FC9963}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9E9052E5-A217-477D-8A1A-010AA7A588AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E9052E5-A217-477D-8A1A-010AA7A588AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9E9052E5-A217-477D-8A1A-010AA7A588AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9E9052E5-A217-477D-8A1A-010AA7A588AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FC9EC8AD-F2C3-4FFD-916C-2A3639DB9AE4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC9EC8AD-F2C3-4FFD-916C-2A3639DB9AE4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FC9EC8AD-F2C3-4FFD-916C-2A3639DB9AE4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FC9EC8AD-F2C3-4FFD-916C-2A3639DB9AE4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{909515FA-7AFD-4E77-907F-8E776784DF1C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{909515FA-7AFD-4E77-907F-8E776784DF1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{909515FA-7AFD-4E77-907F-8E776784DF1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{909515FA-7AFD-4E77-907F-8E776784DF1C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{9E9052E5-A217-477D-8A1A-010AA7A588AF} = {FF964C86-C884-453C-ACE4-41A5ACBBF2C7}
+		{FC9EC8AD-F2C3-4FFD-916C-2A3639DB9AE4} = {FF964C86-C884-453C-ACE4-41A5ACBBF2C7}
+		{909515FA-7AFD-4E77-907F-8E776784DF1C} = {FF964C86-C884-453C-ACE4-41A5ACBBF2C7}
 	EndGlobalSection
 EndGlobal

--- a/source/Loggly.Config/AppConfigPartials/LogglyConfig.cs
+++ b/source/Loggly.Config/AppConfigPartials/LogglyConfig.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if FEATURE_SYSTEM_CONFIGURATION
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -23,3 +24,4 @@ namespace Loggly.Config
         }
     }
 }
+#endif

--- a/source/Loggly.Config/ApplicationNameProvider.cs
+++ b/source/Loggly.Config/ApplicationNameProvider.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if FEATURE_SYSTEM_CONFIGURATION
+using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.Linq;
@@ -36,3 +37,4 @@ namespace Loggly.Config
         }
     }
 }
+#endif

--- a/source/Loggly.Config/Loggly.Config.csproj
+++ b/source/Loggly.Config/Loggly.Config.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;FEATURE_SYSTEM_CONFIGURATION FEATURE_SYSTEM_ENVIRONMENT_OSVERSION</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -28,7 +28,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;FEATURE_SYSTEM_CONFIGURATION FEATURE_SYSTEM_ENVIRONMENT_OSVERSION</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -77,6 +77,7 @@
     <None Include="ConfigurationSection.csd">
       <Generator>CsdFileGenerator</Generator>
       <LastGenOutput>ConfigurationSection1.csd.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </None>
     <None Include="ConfigurationSection.csd.config">
       <DependentUpon>ConfigurationSection.csd</DependentUpon>

--- a/source/Loggly.Config/Loggly.Config.nuspec
+++ b/source/Loggly.Config/Loggly.Config.nuspec
@@ -1,17 +1,31 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <id>loggly-csharp-config</id>
+    <id>loggly-csharp-config-netcore</id>
     <title>loggly-csharp-config</title>
     <version>$version$</version>
     <authors>neutmute</authors>
     <projectUrl>https://github.com/neutmute/loggly-csharp</projectUrl>
     <iconUrl>https://raw.githubusercontent.com/neutmute/loggly-csharp/master/SolutionItems/loggly-config.png</iconUrl>
-    <description>$description$</description>
+    <description>Configuration classes for loggly clients. Settings are read from app.config or can be programmatically injected at runtime. See readme.md for documentation</description>
     <language>en-US</language>
     <tags>loggly</tags>
+    <dependencies>
+      <group targetFramework="net45" />
+      <group targetFramework=".NETStandard1.5">
+        <dependency id="System.Collections" version="4.0.11" />
+        <dependency id="System.Diagnostics.Tools" version="4.0.1" />
+        <dependency id="System.Linq" version="4.1.0" />
+        <dependency id="System.Runtime.Extensions" version="4.1.0" />
+        <dependency id="System.Text.RegularExpressions" version="4.1.0" />
+        <dependency id="System.Threading.Tasks" version="4.0.11" />
+      </group>
+    </dependencies>
   </metadata>
   <files>
-		<file src="bin\release\Loggly.Config.pdb" target="lib\net45\" />    
-	</files>
+    <file src="bin\$configuration$\Loggly.Config.dll" target="lib\net45\" />
+    <file src="bin\$configuration$\Loggly.Config.pdb" target="lib\net45\" />
+    <file src="..\NetStandard\Loggly.Config\bin\$configuration$\netstandard1.5\Loggly.Config.dll" target="lib\netstandard1.5" />
+    <file src="..\NetStandard\Loggly.Config\bin\$configuration$\netstandard1.5\Loggly.Config.pdb" target="lib\netstandard1.5" />
+  </files>
 </package>

--- a/source/Loggly.Config/LogglyConfig.cs
+++ b/source/Loggly.Config/LogglyConfig.cs
@@ -1,9 +1,7 @@
-﻿using System;
+﻿#if FEATURE_SYSTEM_CONFIGURATION
 using System.Configuration;
+#endif
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
-using System.Net;
 
 namespace Loggly.Config
 {
@@ -37,14 +35,14 @@ namespace Loggly.Config
             {
                 if (_instance == null)
                 {
+#if FEATURE_SYSTEM_CONFIGURATION
                     if (LogglyAppConfig.HasAppCopnfig)
                     {
                         _instance = FromAppConfig();
+                        return _instance;
                     }
-                    else
-                    {
-                        _instance = GetNullConfig();
-                    }
+#endif
+                    _instance = GetNullConfig();
                 }
                 return _instance;
             }
@@ -56,6 +54,7 @@ namespace Loggly.Config
             return new LogglyConfig();
         }
 
+#if FEATURE_SYSTEM_CONFIGURATION
         private static ILogglyConfig FromAppConfig()
         {
             var config = new LogglyConfig();
@@ -77,5 +76,6 @@ namespace Loggly.Config
 
             return config;
         }
+#endif
     }
 }

--- a/source/Loggly.Config/Tags/ComplexTags/OperatingSystemPlatformTag.cs
+++ b/source/Loggly.Config/Tags/ComplexTags/OperatingSystemPlatformTag.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if FEATURE_SYSTEM_ENVIRONMENT_OSVERSION
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -13,3 +14,4 @@ namespace Loggly
         }
     }
 }
+#endif

--- a/source/Loggly.Config/Tags/ComplexTags/OperatingSystemVersionTag.cs
+++ b/source/Loggly.Config/Tags/ComplexTags/OperatingSystemVersionTag.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if FEATURE_SYSTEM_ENVIRONMENT_OSVERSION
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -13,3 +14,4 @@ namespace Loggly
         }
     }
 }
+#endif

--- a/source/Loggly.Tests/Loggly.Tests.csproj
+++ b/source/Loggly.Tests/Loggly.Tests.csproj
@@ -31,11 +31,40 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit3TestAdapter.3.4.1\lib\Mono.Cecil.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit3TestAdapter.3.4.1\lib\Mono.Cecil.Mdb.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit3TestAdapter.3.4.1\lib\Mono.Cecil.Pdb.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit3TestAdapter.3.4.1\lib\Mono.Cecil.Rocks.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Moq">
       <HintPath>..\..\packages\Moq.4.2.1409.1722\lib\net40\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.engine, Version=3.4.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit3TestAdapter.3.4.1\lib\nunit.engine.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit3TestAdapter.3.4.1\lib\nunit.engine.api.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.4.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.4.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NUnit3.TestAdapter, Version=3.4.1.0, Culture=neutral, PublicKeyToken=4cb40d35494691ac, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit3TestAdapter.3.4.1\lib\NUnit3.TestAdapter.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -68,6 +97,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/source/Loggly.Tests/Loggly.Tests.csproj
+++ b/source/Loggly.Tests/Loggly.Tests.csproj
@@ -31,6 +31,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit3TestAdapter.3.4.1\lib\Mono.Cecil.dll</HintPath>
       <Private>True</Private>
@@ -47,8 +51,9 @@
       <HintPath>..\..\packages\NUnit3TestAdapter.3.4.1\lib\Mono.Cecil.Rocks.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Moq">
-      <HintPath>..\..\packages\Moq.4.2.1409.1722\lib\net40\Moq.dll</HintPath>
+    <Reference Include="Moq, Version=4.6.38.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moq.4.6.38-alpha\lib\net45\Moq.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.engine, Version=3.4.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit3TestAdapter.3.4.1\lib\nunit.engine.dll</HintPath>

--- a/source/Loggly.Tests/Loggly/ExtensionMethods/DateTimeExtensionsFixture.cs
+++ b/source/Loggly.Tests/Loggly/ExtensionMethods/DateTimeExtensionsFixture.cs
@@ -30,8 +30,8 @@ namespace Loggly.Tests.Loggly.ExtensionMethods
             // Make this work outside of my timezone
             var syslogForm = date.ToSyslog();
             Assert.AreEqual(32, syslogForm.Length);
-            Assert.That(syslogForm.StartsWith("2013-10-11T22:14:15.003000+"));
-            Assert.That(syslogForm.EndsWith(":00"));
+            Assert.That(syslogForm.StartsWith("2013-10-11T22:14:15.003000"), "Expect syslogForm starting with \"2013-10-11T22:14:15.003000\", actual value \"{0}\"", syslogForm);
+            Assert.That(syslogForm.EndsWith(":00"), "Expect syslogForm ending with \":00\", actual value \"{0}\"", syslogForm);
 
             Console.WriteLine(DateTime.UtcNow.ToSyslog());
         }

--- a/source/Loggly.Tests/packages.config
+++ b/source/Loggly.Tests/packages.config
@@ -1,6 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Moq" version="4.2.1409.1722" targetFramework="net451" />
-  <package id="NUnit" version="2.6.3" targetFramework="net451" />
-  <package id="NUnit.Runners" version="2.6.3" targetFramework="net451" />
+  <package id="NUnit" version="3.4.1" targetFramework="net451" />
+  <package id="NUnit.ConsoleRunner" version="3.4.1" targetFramework="net451" />
+  <package id="NUnit.Extension.NUnitProjectLoader" version="3.4.1" targetFramework="net451" />
+  <package id="NUnit.Extension.NUnitV2Driver" version="3.4.1" targetFramework="net451" />
+  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.4.1" targetFramework="net451" />
+  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.1" targetFramework="net451" />
+  <package id="NUnit.Extension.VSProjectLoader" version="3.4.1" targetFramework="net451" />
+  <package id="NUnit.Runners" version="3.4.1" targetFramework="net451" />
+  <package id="NUnit3TestAdapter" version="3.4.1" targetFramework="net451" />
 </packages>

--- a/source/Loggly.Tests/packages.config
+++ b/source/Loggly.Tests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.2.1409.1722" targetFramework="net451" />
+  <package id="Castle.Core" version="3.3.3" targetFramework="net451" />
+  <package id="Moq" version="4.6.38-alpha" targetFramework="net451" />
   <package id="NUnit" version="3.4.1" targetFramework="net451" />
   <package id="NUnit.ConsoleRunner" version="3.4.1" targetFramework="net451" />
   <package id="NUnit.Extension.NUnitProjectLoader" version="3.4.1" targetFramework="net451" />

--- a/source/Loggly/Loggly.csproj
+++ b/source/Loggly/Loggly.csproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -42,6 +42,16 @@
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.Primitives, Version=4.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
@@ -104,6 +114,11 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/source/Loggly/Loggly.nuspec
+++ b/source/Loggly/Loggly.nuspec
@@ -1,18 +1,38 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
-        <id>loggly-csharp</id>
+        <id>loggly-csharp-netcore</id>
         <version>$version$</version>
         <title>loggly-csharp</title>
         <authors>neutmute</authors>
         <projectUrl>https://github.com/neutmute/loggly-csharp</projectUrl>
         <iconUrl>https://raw.githubusercontent.com/neutmute/loggly-csharp/master/SolutionItems/loggly.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>$description$</description>
+        <description>A .NET client for loggly. Supporting Https, Syslog UDP and encrypted Syslog TCP transports.</description>
         <language>en-US</language>
         <tags>loggly</tags>
+        <dependencies>
+            <group targetFramework="net45">
+                <dependency id="loggly-csharp-config-netcore" version="$version$" />
+                <dependency id="Newtonsoft.Json" version="6.0.8" />
+            </group>
+            <group targetFramework=".NETStandard1.5">
+                <dependency id="System.Diagnostics.Process" version="4.1.0" />
+                <dependency id="System.Net.Http" version="4.1.0" />
+                <dependency id="System.Net.NameResolution" version="4.0.0" />
+                <dependency id="System.Net.Requests" version="4.0.11" />
+                <dependency id="System.Net.Security" version="4.0.0" />
+                <dependency id="System.Net.Sockets" version="4.1.0" />
+                <dependency id="System.Diagnostics.Tracing" version="4.1.0" />
+                <dependency id="loggly-csharp-config-netcore" version="$version$" />
+                <dependency id="Newtonsoft.Json" version="9.0.1" />
+            </group>
+        </dependencies>
     </metadata>
-	<files>
-		<file src="bin\release\Loggly.pdb" target="lib\net45\" />    
-	</files>
+    <files>
+        <file src="bin\$configuration$\Loggly.dll" target="lib\net45\" />
+        <file src="bin\$configuration$\Loggly.pdb" target="lib\net45\" />
+        <file src="..\NetStandard\Loggly\bin\$configuration$\netstandard1.5\Loggly.dll" target="lib\netstandard1.5" />
+        <file src="..\NetStandard\Loggly\bin\$configuration$\netstandard1.5\Loggly.pdb" target="lib\netstandard1.5" />
+    </files>
 </package>

--- a/source/Loggly/Responses/Search/SearchResponse.cs
+++ b/source/Loggly/Responses/Search/SearchResponse.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
-using System.Web.UI;
 using Newtonsoft.Json;
 
 namespace Loggly.Responses

--- a/source/Loggly/Transports/SyslogTransports/SyslogTcpTransport.cs
+++ b/source/Loggly/Transports/SyslogTransports/SyslogTcpTransport.cs
@@ -20,7 +20,8 @@ namespace Loggly.Transports.Syslog
 
         protected override async Task Send(SyslogMessage syslogMessage)
         {
-            var client = new TcpClient(Hostname, LogglyConfig.Instance.Transport.EndpointPort);
+            var client = new TcpClient();
+            client.ConnectAsync(Hostname, LogglyConfig.Instance.Transport.EndpointPort).Wait();
 
             try
             {
@@ -35,7 +36,11 @@ namespace Loggly.Transports.Syslog
             }
             finally
             {
+#if NET_STANDARD
+                client.Dispose();
+#else
                 client.Close();
+#endif
             }
 
         }

--- a/source/Loggly/Transports/SyslogTransports/UdpClientEx.cs
+++ b/source/Loggly/Transports/SyslogTransports/UdpClientEx.cs
@@ -12,7 +12,12 @@ namespace Loggly.Transports.Syslog
         public UdpClientEx(IPEndPoint ipe) : base (ipe) { }
         ~UdpClientEx()
         {
-            if (Active) Close();
+            if (Active)
+#if NET_STANDARD
+                Dispose();
+#else
+                Close();
+#endif
         }
 
         public bool IsActive

--- a/source/Loggly/packages.config
+++ b/source/Loggly/packages.config
@@ -1,4 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
+  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
 </packages>

--- a/source/NetStandard/Loggly.Config/LogTransport.cs
+++ b/source/NetStandard/Loggly.Config/LogTransport.cs
@@ -1,0 +1,30 @@
+namespace Loggly.Config
+{
+    /// <summary>
+    /// LogTransport.
+    /// </summary>
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ConfigurationSectionDesigner.CsdFileGenerator", "2.0.1.7")]
+    public enum LogTransport
+    {
+
+        /// <summary>
+        /// Https.
+        /// </summary>
+        Https,
+
+        /// <summary>
+        /// SyslogSecure.
+        /// </summary>
+        SyslogSecure,
+
+        /// <summary>
+        /// SyslogUdp.
+        /// </summary>
+        SyslogUdp,
+
+        /// <summary>
+        /// SyslogTcp.
+        /// </summary>
+        SyslogTcp,
+    }
+}

--- a/source/NetStandard/Loggly.Config/Loggly.Config.NetStandard.xproj
+++ b/source/NetStandard/Loggly.Config/Loggly.Config.NetStandard.xproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>fc9ec8ad-f2c3-4ffd-916c-2a3639db9ae4</ProjectGuid>
+    <RootNamespace>Loggly.Config</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/source/NetStandard/Loggly.Config/project.json
+++ b/source/NetStandard/Loggly.Config/project.json
@@ -1,0 +1,30 @@
+{
+  "title"  : "loggly-csharp-config-netcore",
+  "version": "4.6.0-*",
+  "description": "Configuration classes for loggly clients. Settings are read from app.config or can be programmatically injected at runtime. See readme.md for documentation",
+
+  "buildOptions": {
+    "define": [ "NET_STANDARD" ],
+    "compile": {
+      "include": [ "../../loggly.Config/**/*.cs" ],
+      "exclude": [
+        "../../loggly.Config/ConfigurationSection*.*",
+        "../../loggly.Config/AppConfigPartials/*.cs"
+      ]
+    }
+  },
+  "dependencies": {
+  },
+  "frameworks": {
+    "netstandard1.5": {
+      "dependencies": {
+        "System.Collections": "4.0.11",
+        "System.Diagnostics.Tools": "4.0.1",
+        "System.Linq": "4.1.0",
+        "System.Runtime.Extensions": "4.1.0",
+        "System.Text.RegularExpressions": "4.1.0",
+        "System.Threading.Tasks": "4.0.11"
+      }
+    }
+  }
+}

--- a/source/NetStandard/Loggly.Tests/Loggly.Tests.NetStandard.xproj
+++ b/source/NetStandard/Loggly.Tests/Loggly.Tests.NetStandard.xproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>909515fa-7afd-4e77-907f-8e776784df1c</ProjectGuid>
+    <RootNamespace>Loggly.Tests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/source/NetStandard/Loggly.Tests/project.json
+++ b/source/NetStandard/Loggly.Tests/project.json
@@ -1,0 +1,26 @@
+{
+  "buildOptions": {
+    "define": [ "NET_STANDARD" ],
+    "compile": {
+      "include": [ "../../loggly.Tests/**/*.cs" ]
+    }
+  },
+  "testRunner": "nunit",
+  "dependencies": {
+    "Loggly": { "target": "project", "version": "" },
+    "Moq": "4.6.36-alpha",
+    "NUnit": "3.4.1",
+    "dotnet-test-nunit": "3.4.0-beta-2"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": "portable-net45+win8",
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.0",
+          "type": "platform"
+        }
+      }
+    }
+  }
+}

--- a/source/NetStandard/Loggly.Tests/project.json
+++ b/source/NetStandard/Loggly.Tests/project.json
@@ -8,9 +8,9 @@
   "testRunner": "nunit",
   "dependencies": {
     "Loggly": { "target": "project", "version": "" },
-    "Moq": "4.6.36-alpha",
     "NUnit": "3.4.1",
-    "dotnet-test-nunit": "3.4.0-beta-2"
+    "dotnet-test-nunit": "3.4.0-beta-2",
+    "Moq": "4.6.38-alpha"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/source/NetStandard/Loggly/Loggly.NetStandard.xproj
+++ b/source/NetStandard/Loggly/Loggly.NetStandard.xproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>9e9052e5-a217-477d-8a1a-010aa7a588af</ProjectGuid>
+    <RootNamespace>Loggly</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/source/NetStandard/Loggly/project.json
+++ b/source/NetStandard/Loggly/project.json
@@ -1,0 +1,35 @@
+{
+  "title" : "loggly-csharp-netcore",
+  "version": "4.6.0-*",
+  "description": "A .NET client for loggly. Supporting Https, Syslog UDP and encrypted Syslog TCP transports.",
+
+  "buildOptions": {
+    "define": [ "NET_STANDARD" ],
+    "compile": {
+      "include": [
+        "../../loggly/**/*.cs",
+        "../../../SolutionItems/Properties/AssemblyInfo.cs"
+      ]
+    }
+  },
+  "dependencies": {
+    "Loggly.Config": {
+      "target": "project",
+      "version": ""
+    },
+    "Newtonsoft.Json": "9.0.1"
+  },
+  "frameworks": {
+    "netstandard1.5": {
+      "dependencies": {
+        "System.Diagnostics.Process": "4.1.0",
+        "System.Net.Http": "4.1.0",
+        "System.Net.NameResolution": "4.0.0",
+        "System.Net.Requests": "4.0.11",
+        "System.Net.Security": "4.0.0",
+        "System.Net.Sockets": "4.1.0",
+        "System.Diagnostics.Tracing": "4.1.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Upgrade to NUnit v3
- Rewrite http transport using HttpClient
- Add projects targeting .NET STandard
- Update the build scripts and .nuspec files

App.config is not supported on .NET Standard.

For #39 

This PR needs the new tooling: https://www.microsoft.com/net/core#windows. 

I have successful appveyor builds on https://ci.appveyor.com/project/jeremymeng/loggly-csharp. 