### PR TITLE
version was missing from the .NETStandard config project 

### DIFF
--- a/source/NetStandard/Loggly.Config/Loggly.Config.csproj
+++ b/source/NetStandard/Loggly.Config/Loggly.Config.csproj
@@ -14,11 +14,15 @@
 	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Remove="..\..\loggly.Config\ConfigurationSection*.*;..\..\loggly.Config\AppConfigPartials\*.cs" />
-    <Compile Include="..\..\loggly.Config\**\*.cs" Exclude="..\..\loggly.Config\ConfigurationSection*.*;..\..\loggly.Config\AppConfigPartials\*.cs;bin\**;obj\**;**\*.xproj;packages\**" />
+    <Compile Include="..\..\loggly.Config\**\*.cs;..\..\..\SolutionItems\Properties\AssemblyInfo.cs" Exclude="..\..\loggly.Config\ConfigurationSection*.*;..\..\loggly.Config\AppConfigPartials\*.cs;bin\**;obj\**;**\*.xproj;packages\**" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">


### PR DESCRIPTION
This caused exceptions after upgrading to new version of the package