### PR TITLE
Allowing the LogglyClient message creation be overridden in derived classes

### DIFF
--- a/source/Loggly/Events/LogglyMessage.cs
+++ b/source/Loggly/Events/LogglyMessage.cs
@@ -7,12 +7,12 @@ using Loggly.Transports.Syslog;
 
 namespace Loggly
 {
-    internal enum MessageType
+    public enum MessageType
     {
         Plain,
         Json
     }
-    internal class LogglyMessage
+    public class LogglyMessage
     {
         public DateTimeOffset Timestamp { get; set; }
         public SyslogHeader Syslog { get; set; }
@@ -33,7 +33,7 @@ namespace Loggly
         }
     }
 
-    internal enum HttpRequestType
+    public enum HttpRequestType
     {
         Get
         ,Post

--- a/source/Loggly/LogglyClient.cs
+++ b/source/Loggly/LogglyClient.cs
@@ -50,14 +50,7 @@ namespace Loggly
 						}
                     }
                     
-                    response = await _transport.Send(events.Select(x => new LogglyMessage
-                    {
-                        Timestamp = x.Timestamp,
-                        Syslog = x.Syslog,
-                        Type = MessageType.Json,
-                        Content = ToJson(x.Data),
-                        CustomTags = x.Options.Tags
-                    })).ConfigureAwait(false);
+                    response = await _transport.Send(events.Select(BuildMessage)).ConfigureAwait(false);
                 }
                 else
                 {
@@ -69,6 +62,18 @@ namespace Loggly
                 LogglyException.Throw(e);
             }
             return response;
+        }
+
+        protected virtual LogglyMessage BuildMessage(LogglyEvent logglyEvent)
+        {
+            return new LogglyMessage
+                   {
+                       Timestamp = logglyEvent.Timestamp,
+                       Syslog = logglyEvent.Syslog,
+                       Type = MessageType.Json,
+                       Content = ToJson(logglyEvent.Data),
+                       CustomTags = logglyEvent.Options.Tags
+                   };
         }
 
         private static string ToJson(object value)


### PR DESCRIPTION
**The Problem**
When trying to use this in conjunction with your nlog-targets-loggly project, I ran into an an issue where messages formatted with a JsonLayout configuration did not display correctly in Loggly. What would happen is the message JSON would get escaped during the LogglyClient.ToJSON() method. Here is an example raw message from Loggly:

`{"sequenceId":67,"level":"Debug","message":"{ \"time\": \"2017-08-02 19:27:18.7257\", \"level\": \"DEBUG\", \"message\": \"Aggregating records in 'Counter' table...\", \"context\": {  } }","timestamp":"2017-08-02T19:27:18.7257231-06:00"}`

In loggly, the escaped quotes display correctly but do not parse to JSON. This prevents searching or filtering by any of the values.

**Simple Fix**
For this pull request I tried to change as little as possible. Moving the message conversion from a static private into a protected virtual method accomplished what I needed

**Better Fix**
Ideally the LogglyEvent.Data property should be something more flexible than a dictionary. It is rarely used as a dictionary by your code. The only place I could find where it had to be a dictionary was to automatically add a timestamp when the log transport is Https.

In my personal project, I will be changing LogglyEvent.Data to a plain object. There are no requirements for the JSON conversion so the Data property can be very flexible. You can even use a dictionary if you want. I did not include these changes in the pull request because this would be a breaking change for anyone who relied on the automatic addition of "timestamp".