### PR TITLE
Add missing field name to search

### DIFF
--- a/source/Loggly/Transports/SearchTransport.cs
+++ b/source/Loggly/Transports/SearchTransport.cs
@@ -47,7 +47,7 @@ namespace Loggly
         public FieldResponse Search(FieldQuery query)
         {
             var parameters = query.ToParameters();
-            return Search<FieldResponse>("apiv2/fields", parameters);
+            return Search<FieldResponse>($"apiv2/fields/{query.FieldName}/", parameters);
         }
 
         private T Search<T>(string endPoint, IDictionary<string, object> parameters)


### PR DESCRIPTION
A field search was not working. It was throwing a `NullReferenceException`.

`FieldResponse` class expects a response with properties such as `unique_field_count` and a collection of fields containing `term`. As per documentation on https://www.loggly.com/docs/api-retrieving-data/#facet - we need to include the field in the URL.

This PR fixes it. Hope we can get an updated NuGet package soon?