### PR TITLE
Add missing .ConfigureAwait(false) that could cause deadlocks

### DIFF
--- a/source/Loggly.Example/LogglyExample.cs
+++ b/source/Loggly.Example/LogglyExample.cs
@@ -58,7 +58,7 @@ namespace Loggly.Example
             var logEvent = new LogglyEvent();
             logEvent.Data.Add("message", "Log event sent with forced transport={0}", transport);
             logEvent.Options.Tags.Add("secondCustomTag");
-            await _loggly.Log(logEvent);
+            await _loggly.Log(logEvent).ConfigureAwait(false);
 
             LogglyConfig.Instance.Transport = priorTransport;
         }

--- a/source/Loggly/Transports/HttpTransports/HttpMessageTransport.cs
+++ b/source/Loggly/Transports/HttpTransports/HttpMessageTransport.cs
@@ -168,7 +168,7 @@ namespace Loggly
             {
                 return null;
             }
-            return await response.Content.ReadAsStringAsync();
+            return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
         }
     }
 }

--- a/source/Loggly/Transports/SyslogTransports/SyslogTransportBase.cs
+++ b/source/Loggly/Transports/SyslogTransports/SyslogTransportBase.cs
@@ -12,7 +12,7 @@ namespace Loggly.Transports.Syslog
             foreach (var message in messages)
             {
                 var sysLog = ConstructSyslog(message);
-                await Send(sysLog);
+                await Send(sysLog).ConfigureAwait(false);
 
                 var response = new LogResponse
                 {


### PR DESCRIPTION
`SyslogTransportBase` is missing a `.ConfigureAwait(false)` that resulted in a deadlock in my code. Here's a PR to fix that + added some more missing `.ConfigureAwait(false)` statements.