### PR TITLE
Convert LogglySearchClient and SearchTransport to use async.

### DIFF
--- a/source/Loggly.Example/MainForm.cs
+++ b/source/Loggly.Example/MainForm.cs
@@ -62,7 +62,7 @@ namespace Loggly.Example
             query.Until = DateTime.Now;
             query.Size = 2;
 
-            _searchResponse = searchClient.Search(query);
+            _searchResponse = searchClient.Search(query).Result;
             txtSearchResult.Text = _searchResponse.ToString();
         }
 

--- a/source/Loggly/Interfaces/ISearchClient.cs
+++ b/source/Loggly/Interfaces/ISearchClient.cs
@@ -1,18 +1,19 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Loggly.Responses;
 
 namespace Loggly
 {
    public interface ISearchClient
    {
-       SearchResponse Search(string query);
-       SearchResponse Search(string query, DateTime start, DateTime until);
-       SearchResponse Search(string query, DateTime start, DateTime until, int size);
-       SearchResponse Search(SearchQuery query);
-       SearchResponse<TMessage> Search<TMessage>(string query);
-       SearchResponse<TMessage> Search<TMessage>(string query, DateTime start, DateTime until);
-       SearchResponse<TMessage> Search<TMessage>(string query, DateTime start, DateTime until, int size);
-       SearchResponse<TMessage> Search<TMessage>(SearchQuery query);
-       FieldResponse Field(FieldQuery query);
+       Task<SearchResponse> Search(string query);
+       Task<SearchResponse> Search(string query, DateTime start, DateTime until);
+       Task<SearchResponse> Search(string query, DateTime start, DateTime until, int size);
+       Task<SearchResponse> Search(SearchQuery query);
+       Task<SearchResponse<TMessage>> Search<TMessage>(string query);
+       Task<SearchResponse<TMessage>> Search<TMessage>(string query, DateTime start, DateTime until);
+       Task<SearchResponse<TMessage>> Search<TMessage>(string query, DateTime start, DateTime until, int size);
+       Task<SearchResponse<TMessage>> Search<TMessage>(SearchQuery query);
+       Task<FieldResponse> Field(FieldQuery query);
    }
 }

--- a/source/Loggly/LogglySearchClient.cs
+++ b/source/Loggly/LogglySearchClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 using Loggly.Config;
 using Loggly.Responses;
 
@@ -20,47 +21,47 @@ namespace Loggly
         }
 
 
-        public SearchResponse Search(string query)
+        public Task<SearchResponse> Search(string query)
         {
             return Search(new SearchQuery { Query = query });
         }
 
-        public SearchResponse Search(string query, DateTime start, DateTime until)
+        public Task<SearchResponse> Search(string query, DateTime start, DateTime until)
         {
             return Search(new SearchQuery { Query = query, From = start, Until = until });
         }
 
-        public SearchResponse Search(string query, DateTime start, DateTime until, int size)
+        public Task<SearchResponse> Search(string query, DateTime start, DateTime until, int size)
         {
             return Search(new SearchQuery { Query = query, From = start, Until = until, Size = size});
         }
 
-        public SearchResponse Search(SearchQuery query)
+        public Task<SearchResponse> Search(SearchQuery query)
         {
             return _transport.Search(query);
         }
 
-        public SearchResponse<TMessage> Search<TMessage>(string query)
+        public Task<SearchResponse<TMessage>> Search<TMessage>(string query)
         {
             return Search<TMessage>(new SearchQuery { Query = query });
         }
 
-        public SearchResponse<TMessage> Search<TMessage>(string query, DateTime start, DateTime until)
+        public Task<SearchResponse<TMessage>> Search<TMessage>(string query, DateTime start, DateTime until)
         {
             return Search<TMessage>(new SearchQuery { Query = query, From = start, Until = until });
         }
 
-        public SearchResponse<TMessage> Search<TMessage>(string query, DateTime start, DateTime until, int size)
+        public Task<SearchResponse<TMessage>> Search<TMessage>(string query, DateTime start, DateTime until, int size)
         {
             return Search<TMessage>(new SearchQuery { Query = query, From = start, Until = until, Size = size });
         }
 
-        public SearchResponse<TMessage> Search<TMessage>(SearchQuery query)
+        public Task<SearchResponse<TMessage>> Search<TMessage>(SearchQuery query)
         {
             return _transport.Search<TMessage>(query);
         }
 
-        public FieldResponse Field(FieldQuery query)
+        public Task<FieldResponse> Field(FieldQuery query)
         {
             return _transport.Search(query);
         }

--- a/source/Loggly/Responses/Search/SearchResponse.cs
+++ b/source/Loggly/Responses/Search/SearchResponse.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace Loggly.Responses
@@ -12,7 +13,7 @@ namespace Loggly.Responses
         {
             int page = 0;
             int returnedEntryCount = 0;
-            var entryResonse = this.FirstEntryResponse ?? GetEntryJsonResponse(page);
+            var entryResonse = this.FirstEntryResponse ?? GetEntryJsonResponse(page).Result;
 
             while (true)
             {
@@ -26,7 +27,7 @@ namespace Loggly.Responses
                     yield break;
 
                 page++;
-                entryResonse = GetEntryJsonResponse(page);
+                entryResonse = GetEntryJsonResponse(page).Result;
             }
 
         }
@@ -36,10 +37,10 @@ namespace Loggly.Responses
             return GetEnumerator();
         }
 
-        protected override EntryJsonResponseBase GetEntryJsonResponse(int page)
+        protected override async Task<EntryJsonResponseBase> GetEntryJsonResponse(int page)
         {
             var eventQuery = new EventQuery {Rsid = this.Rsid.Id, Page = page};
-            var entryResonse = this.Transport.Search(eventQuery);
+            var entryResonse = await this.Transport.Search(eventQuery).ConfigureAwait(false);
             return entryResonse;
         }
     }

--- a/source/Loggly/Responses/Search/SearchResponseBase.cs
+++ b/source/Loggly/Responses/Search/SearchResponseBase.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace Loggly.Responses
 {
@@ -19,14 +20,14 @@ namespace Loggly.Responses
             {
                 if (this.FirstEntryResponse == null)
                 {
-                    this.FirstEntryResponse = GetEntryJsonResponse(0);
+                    this.FirstEntryResponse = GetEntryJsonResponse(0).Result;
                 }
 
                 return this.FirstEntryResponse.TotalEvents;
             }
         }
 
-        protected abstract EntryJsonResponseBase GetEntryJsonResponse(int page);
+        protected abstract Task<EntryJsonResponseBase> GetEntryJsonResponse(int page);
 
         public override string ToString()
         {

--- a/source/Loggly/Responses/Search/SearchResponseT.cs
+++ b/source/Loggly/Responses/Search/SearchResponseT.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace Loggly.Responses
@@ -11,7 +12,7 @@ namespace Loggly.Responses
         {
             int page = 0;
             int returnedEntryCount = 0;
-            var entryResonse = FirstEntryResponse ?? GetEntryJsonResponse(page);
+            var entryResonse = FirstEntryResponse ?? GetEntryJsonResponse(page).Result;
 
             while (true)
             {
@@ -25,7 +26,7 @@ namespace Loggly.Responses
                     yield break;
 
                 page++;
-                entryResonse = GetEntryJsonResponse(page);
+                entryResonse = GetEntryJsonResponse(page).Result;
             }
 
         }
@@ -35,10 +36,10 @@ namespace Loggly.Responses
             return GetEnumerator();
         }
 
-        protected override EntryJsonResponseBase GetEntryJsonResponse(int page)
+        protected override async Task<EntryJsonResponseBase> GetEntryJsonResponse(int page)
         {
             var eventQuery = new EventQuery { Rsid = this.Rsid.Id, Page = page };
-            var entryResonse = this.Transport.Search(eventQuery);
+            var entryResonse = await this.Transport.Search(eventQuery).ConfigureAwait(false);
             return entryResonse;
         }
     }

--- a/source/Loggly/Transports/Interfaces/ISearchTransport.cs
+++ b/source/Loggly/Transports/Interfaces/ISearchTransport.cs
@@ -1,15 +1,16 @@
 using Loggly.Config;
 using Loggly.Responses;
+using System.Threading.Tasks;
 
 namespace Loggly
 {
     public interface ISearchTransport
     {
-        SearchResponse Search(SearchQuery query);
-        EntryJsonResponseBase Search(EventQuery query);
+        Task<SearchResponse> Search(SearchQuery query);
+        Task<EntryJsonResponseBase> Search(EventQuery query);
 
-        SearchResponse<T> Search<T>(SearchQuery query);
+        Task<SearchResponse<T>> Search<T>(SearchQuery query);
 
-        FieldResponse Search(FieldQuery query);
+        Task<FieldResponse> Search(FieldQuery query);
     }
 }

--- a/source/Loggly/Transports/SearchTransport.cs
+++ b/source/Loggly/Transports/SearchTransport.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Threading.Tasks;
 using Loggly.Config;
 using Loggly.Responses;
 using Newtonsoft.Json;
@@ -26,41 +27,41 @@ namespace Loggly
                         Encoding.ASCII.GetBytes(
                         string.Format("{0}:{1}", config.Username, config.Password))));
         }
-        public SearchResponse Search(SearchQuery query)
+        public async Task<SearchResponse> Search(SearchQuery query)
         {
             var parameters = query.ToParameters();
-            return Search<SearchResponse>("apiv2/search", parameters);
+            return await Search<SearchResponse>("apiv2/search", parameters);
         }
 
-        public SearchResponse<T> Search<T>(SearchQuery query)
+        public async Task<SearchResponse<T>> Search<T>(SearchQuery query)
         {
             var parameters = query.ToParameters();
-            return Search<SearchResponse<T>>("apiv2/search", parameters);
+            return await Search<SearchResponse<T>>("apiv2/search", parameters);
         }
 
-        public EntryJsonResponseBase Search(EventQuery query)
+        public async Task<EntryJsonResponseBase> Search(EventQuery query)
         {
             var parameters = query.ToParameters();
-            return Search<EntryJsonResponse>("apiv2/events", parameters);
+            return await Search<EntryJsonResponse>("apiv2/events", parameters);
         }
 
-        public FieldResponse Search(FieldQuery query)
+        public async Task<FieldResponse> Search(FieldQuery query)
         {
             var parameters = query.ToParameters();
-            return Search<FieldResponse>($"apiv2/fields/{query.FieldName}/", parameters);
+            return await Search<FieldResponse>($"apiv2/fields/{query.FieldName}/", parameters);
         }
 
-        private T Search<T>(string endPoint, IDictionary<string, object> parameters)
+        private async Task<T> Search<T>(string endPoint, IDictionary<string, object> parameters)
             where T : class
         {
             try
             {
                 var searchPathAndQuery = GetUrl(endPoint, parameters);
                 
-                using (var response = _httpClient.GetAsync(searchPathAndQuery).Result)
+                using (var response = await _httpClient.GetAsync(searchPathAndQuery).ConfigureAwait(false))
                 {
                     var isFieldResponseResultExpected = typeof(T) == typeof(FieldResponse);
-                    var responseBody = response.Content.ReadAsStringAsync().Result;
+                    var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                     if (response.IsSuccessStatusCode)
                     {
                         T responseObject = isFieldResponseResultExpected

--- a/source/Loggly/Transports/SearchTransport.cs
+++ b/source/Loggly/Transports/SearchTransport.cs
@@ -30,25 +30,25 @@ namespace Loggly
         public async Task<SearchResponse> Search(SearchQuery query)
         {
             var parameters = query.ToParameters();
-            return await Search<SearchResponse>("apiv2/search", parameters);
+            return await Search<SearchResponse>("apiv2/search", parameters).ConfigureAwait(false);
         }
 
         public async Task<SearchResponse<T>> Search<T>(SearchQuery query)
         {
             var parameters = query.ToParameters();
-            return await Search<SearchResponse<T>>("apiv2/search", parameters);
+            return await Search<SearchResponse<T>>("apiv2/search", parameters).ConfigureAwait(false);
         }
 
         public async Task<EntryJsonResponseBase> Search(EventQuery query)
         {
             var parameters = query.ToParameters();
-            return await Search<EntryJsonResponse>("apiv2/events", parameters);
+            return await Search<EntryJsonResponse>("apiv2/events", parameters).ConfigureAwait(false);
         }
 
         public async Task<FieldResponse> Search(FieldQuery query)
         {
             var parameters = query.ToParameters();
-            return await Search<FieldResponse>($"apiv2/fields/{query.FieldName}/", parameters);
+            return await Search<FieldResponse>($"apiv2/fields/{query.FieldName}/", parameters).ConfigureAwait(false);
         }
 
         private async Task<T> Search<T>(string endPoint, IDictionary<string, object> parameters)


### PR DESCRIPTION
`SearchTransport.cs` contains the following code:

```
using (var response = _httpClient.GetAsync(searchPathAndQuery).Result)
{
    var isFieldResponseResultExpected = typeof(T) == typeof(FieldResponse);
    var responseBody = response.Content.ReadAsStringAsync().Result;
```


Task.Result is prone to deadlocks. In this pull request I change the `ISearchClient` and `ISearchTransport` to use tasks instead. This is a breaking change of course, but I don't think people appreciate finding deadlocks in their applications. It seems anyway the convention of this library to only support async API (e.g. Log method is async).

Unfortunately I had to keep a `.Result` in `SearchResponse` classes, since the IEnumeable interface cannot be async. This can be improved in future pull request.