### PR TITLE
Improved performance and memory efficiency of MessageData

### DIFF
--- a/source/Loggly.Tests/Loggly.Tests.csproj
+++ b/source/Loggly.Tests/Loggly.Tests.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Loggly.Config\ComplexTags\HostnameTagFixture.cs" />
     <Compile Include="Loggly.Config\TagConfigurationFixture.cs" />
     <Compile Include="Loggly\Client\SerializationDataFixture.cs" />
+    <Compile Include="Loggly\Events\LogglyEventFixture.cs" />
     <Compile Include="Loggly\Events\MessageDataFixture.cs" />
     <Compile Include="Loggly\ExtensionMethods\DateTimeExtensionsFixture.cs" />
     <Compile Include="Loggly\LogglyMessageDataFixture.cs" />

--- a/source/Loggly.Tests/Loggly/Events/LogglyEventFixture.cs
+++ b/source/Loggly.Tests/Loggly/Events/LogglyEventFixture.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Loggly.Tests.Loggly.Events
+{
+    public class LogglyEventFixture : Fixture
+    {
+        [Test]
+        public void CtorWithMessageDataIsSet()
+        {
+            var messageData = MessageData.FromDictionary(new Dictionary<string, object>
+            {
+                {"key1", "value"},
+                {"key2", "value"}
+            });
+
+            var logglyEvent = new LogglyEvent(messageData);
+
+            Assert.That(logglyEvent.Data, Is.EqualTo(messageData));
+        }
+    }
+}

--- a/source/Loggly.Tests/Loggly/Events/MessageDataFixture.cs
+++ b/source/Loggly.Tests/Loggly/Events/MessageDataFixture.cs
@@ -1,14 +1,127 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace Loggly.Tests.Loggly.Events
 {
     public class MessageDataFixture : Fixture
     {
+        [Test]
+        public void CtorWithOutOfRangeCapacityThrowsException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new MessageData(-1));
+        }
+
+        [Test]
+        public void AddFromNullObjectKeyedDictionaryThrowsException()
+        {
+            var messageData = new MessageData();
+
+            Assert.Throws<ArgumentNullException>(() => messageData.AddFromDictionary((IDictionary<object, object>)null));
+        }
+
+        [Test]
+        public void AddFromNullStringKeyedDictionaryThrowsException()
+        {
+            var messageData = new MessageData();
+
+            Assert.Throws<ArgumentNullException>(() => messageData.AddFromDictionary((IDictionary<string, object>)null));
+        }
+
+        [Test]
+        public void AddDuplicateKeysFromObjectKeyedDictionaryThrowsException()
+        {
+            var messageData = new MessageData();
+            var source1 = new Dictionary<object, object>
+            {
+                {"key1", "value"},
+                {"key2", "value"}
+            };
+            messageData.AddFromDictionary(source1);
+            var source2 = new Dictionary<object, object>
+            {
+                {"key1", "value"}
+            };
+
+            Assert.Throws<ArgumentException>(() => messageData.AddFromDictionary(source2));
+        }
+
+        [Test]
+        public void AddDuplicateKeysFromStringKeyedDictionaryThrowsException()
+        {
+            var messageData = new MessageData();
+            var source1 = new Dictionary<string, object>
+            {
+                {"key1", "value"},
+                {"key2", "value"}
+            };
+            messageData.AddFromDictionary(source1);
+            var source2 = new Dictionary<string, object>
+            {
+                {"key1", "value"}
+            };
+
+            Assert.Throws<ArgumentException>(() => messageData.AddFromDictionary(source2));
+        }
+
+        [Test]
+        public void AddFromStringKeyedDictionaryAddsPairs()
+        {
+            var messageData = new MessageData();
+            var source = new Dictionary<string, object>
+            {
+                {"key1", "value"},
+                {"key2", "value"}
+            };
+
+            messageData.AddFromDictionary(source);
+
+            Assert.That(messageData, Is.EquivalentTo(source));
+        }
+
+        [Test]
+        public void AddFromObjectKeyedDictionaryAddsPairs()
+        {
+            var messageData = new MessageData();
+            var source = new Dictionary<object, object>
+            {
+                {"key1", "value"},
+                {"key2", "value"}
+            };
+
+            messageData.AddFromDictionary(source);
+
+            Assert.That(messageData, Is.EquivalentTo(source));
+        }
+
+        [Test]
+        public void InitialiseFromStringKeyedDictionaryAddsPairs()
+        {
+            var source = new Dictionary<string, object>
+            {
+                {"key1", "value"},
+                {"key2", "value"}
+            };
+
+            var messageData = MessageData.FromDictionary(source);
+
+            Assert.That(messageData, Is.EquivalentTo(source));
+        }
+
+        [Test]
+        public void InitialiseFromObjectKeyedDictionaryAddsPairs()
+        {
+            var source = new Dictionary<object, object>
+            {
+                {"key1", "value"},
+                {"key2", "value"}
+            };
+
+            var messageData = MessageData.FromDictionary(source);
+
+            Assert.That(messageData, Is.EquivalentTo(source));
+        }
+        
         /// <summary>
         /// Fix for this exception..
         /// 

--- a/source/Loggly/Events/LogglyEvent.cs
+++ b/source/Loggly/Events/LogglyEvent.cs
@@ -9,17 +9,22 @@ namespace Loggly
         /// <summary>
         /// Metadata to populate into the syslog header
         /// </summary>
-        public SyslogHeader Syslog {get;set;}
+        public SyslogHeader Syslog { get; set; }
 
         public IMessageData Data { get; set; }
 
         public EventOptions Options { get; set; }
 
         public LogglyEvent()
+            : this(new MessageData())
+        {
+        }
+
+        public LogglyEvent(MessageData data)
         {
             Options = new EventOptions();
             Syslog = new SyslogHeader();
-            Data = new MessageData();
+            Data = data;
 
             Timestamp = DateTimeOffset.Now;
         }

--- a/source/Loggly/Events/MessageData.cs
+++ b/source/Loggly/Events/MessageData.cs
@@ -2,25 +2,99 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Newtonsoft.Json;
 
 namespace Loggly
 {
     /// <summary>
-    /// Just a wrapped dictionary
+    /// A dictionary of fields that can be passed to Loggly.
     /// </summary>
     public class MessageData : Dictionary<string, object>, IMessageData
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessageData" /> class that is empty.
+        /// </summary>
+        public MessageData()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessageData" /> class that is empty, and has the specified initial capacity.
+        /// </summary>
+        /// <param name="capacity">The initial number of elements that the <see cref="MessageData" /> can contain.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity" /> is less than 0.</exception>
+        public MessageData(int capacity)
+            : base(capacity)
+        {
+        }
+
         public List<string> KeyList
         {
             get { return Keys.ToList(); }
         }
 
+        /// <summary>
+        /// Populates this instance of the <see cref="MessageData" /> class with content copied from <paramref name="source" />.
+        /// </summary>
+        /// <param name="source">The <see cref="IDictionary{TKey,TValue}"/> whose elements are copied to this <see cref="MessageData"/> object</param>.
+        /// <exception cref="ArgumentNullException"><paramref name="source" /> is null.</exception>
+        /// <exception cref="ArgumentException">An element with the same key already exists in <paramref name="source" />.</exception>
+        public void AddFromDictionary(IDictionary<object, object> source)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            foreach (var pair in source)
+            {
+                this.Add(pair.Key.ToString(), pair.Value);
+            }
+        }
+
+        /// <summary>
+        /// Populates this instance of the <see cref="MessageData" /> class with content copied from <paramref name="source" />.
+        /// </summary>
+        /// <param name="source">The <see cref="IDictionary{TKey,TValue}"/> whose elements are copied to this <see cref="MessageData"/> object</param>.
+        /// <exception cref="ArgumentNullException"><paramref name="source" /> is null.</exception>
+        /// <exception cref="ArgumentException">An element with the same key already exists in <paramref name="source" />.</exception>
+        public void AddFromDictionary(IDictionary<string, object> source)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            foreach (var pair in source)
+            {
+                this.Add(pair.Key, pair.Value);
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessageData" /> class with content copied from <paramref name="source" />.
+        /// </summary>
+        /// <param name="source">The <see cref="IDictionary{TKey,TValue}"/> whose elements are copied to the new <see cref="MessageData"/> object</param>.
+        /// <returns>The new <see cref="MessageData"/> object</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source" /> is null.</exception>
         public static MessageData FromDictionary(IDictionary<object, object> source)
         {
-            var messageData = new MessageData();
-            var asDictionary = source.ToDictionary(k => k.Key != null ? k.Key.ToString() : string.Empty, v => v.Value);
-            asDictionary.ToList().ForEach(x => messageData.Add(x.Key, x.Value));
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            var messageData = new MessageData(source.Count);
+            messageData.AddFromDictionary(source);
+            return messageData;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessageData" /> class with content copied from <paramref name="source" />.
+        /// </summary>
+        /// <param name="source">The <see cref="IDictionary{TKey,TValue}"/> whose elements are copied to the new <see cref="MessageData"/> object</param>.
+        /// <returns>The new <see cref="MessageData"/> object</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source" /> is null.</exception>
+        public static MessageData FromDictionary(IDictionary<string, object> source)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            var messageData = new MessageData(source.Count);
+            messageData.AddFromDictionary(source);
             return messageData;
         }
 


### PR DESCRIPTION
This enhances the use case where `MessageData` needs to be populated frequently, and performance and memory efficiency are important.

A `MessageData` constructor has been added to expose the capacity parameter from the parent dictionary class so that the expected number of items can be allocated early on without .NET guessing. The existing `FromDictionary()` static method has been rewritten to use it, along with adding instance level `AddFromDictionary()` methods.

A `LoggingEvent` constructor that allows providing the `MessageData` as a parameter has also been added, so it is not necessary to throw away or modify capacity of its `Data` property.

Inline documentation and unit tests around these areas have also been added.