### PR TITLE
Tag handling fixes and efficiency improvements

### DIFF
--- a/source/Loggly.Tests/Loggly.Config/TagConfigurationFixture.cs
+++ b/source/Loggly.Tests/Loggly.Config/TagConfigurationFixture.cs
@@ -26,10 +26,10 @@ namespace Loggly.Tests.Loggly.Config
 
             var output = tags.ToLegalStrings();
 
-            Assert.AreEqual("legalTag", output[0]);
-            Assert.AreEqual("z_my_little.pony", output[1]);
-            Assert.AreEqual("z-us", output[2]);
-            Assert.AreEqual("apache_", output[3]);
+            Assert.AreEqual("legalTag", output.ElementAt(0));
+            Assert.AreEqual("z_my_little.pony", output.ElementAt(1));
+            Assert.AreEqual("z-us", output.ElementAt(2));
+            Assert.AreEqual("apache_", output.ElementAt(3));
 
         }
     }

--- a/source/Loggly/Transports/HttpTransports/HttpMessageTransport.cs
+++ b/source/Loggly/Transports/HttpTransports/HttpMessageTransport.cs
@@ -125,19 +125,20 @@ namespace Loggly
                 LogglyException.Throw("Cannot have mixed Plain and Json messages");
             }
 
-            var builder = new StringBuilder();
-            bool isFirst = true;
-            foreach (var m in messages)
+            string messageContent;
+            if (messages.Count == 1)
             {
-                if (isFirst)
-                {
-                    isFirst = false;
-                }
-                else
+                messageContent = messages[0].Content;
+            }
+            else
+            {
+                var builder = new StringBuilder(messages[0].Content);
+                for (var i = 1; i < messages.Count; i++)
                 {
                     builder.Append('\n');
+                    builder.Append(messages[i].Content);
                 }
-                builder.Append(m.Content);
+                messageContent = builder.ToString();
             }
 
             StringContent postData = null;
@@ -145,10 +146,10 @@ namespace Loggly
             switch (type)
             {
                 case MessageType.Plain:
-                    postData = new StringContent(builder.ToString(), Encoding.UTF8, "text/plain");
+                    postData = new StringContent(messageContent, Encoding.UTF8, "text/plain");
                     break;
                 case MessageType.Json:
-                    postData = new StringContent(builder.ToString(), Encoding.UTF8, "application/json");
+                    postData = new StringContent(messageContent, Encoding.UTF8, "application/json");
                     break;
             }
 

--- a/source/Loggly/Transports/SyslogTransports/SyslogTransportBase.cs
+++ b/source/Loggly/Transports/SyslogTransports/SyslogTransportBase.cs
@@ -65,7 +65,7 @@ namespace Loggly.Transports.Syslog
             {
                 sb.AppendFormat("tag=\"{0}\" ", tag);
             }
-            if (tags.Length > 0)
+            if (tags.Count > 0)
             {
                 sb.Remove(sb.Length - 1, 1);
             }

--- a/source/Loggly/Transports/TransportBase.cs
+++ b/source/Loggly/Transports/TransportBase.cs
@@ -13,13 +13,12 @@ namespace Loggly.Transports
         /// <summary>
         /// Combines custom with global tags and makes sure they are loggly legal
         /// </summary>
-        public string[] GetLegalTagUnion(List<ITag> customTags)
+        public ICollection<string> GetLegalTagUnion(List<ITag> customTags)
         {
-            var tagList = new List<ITag>();
-            tagList.AddRange(LogglyConfig.Instance.TagConfig.Tags);
-            tagList.AddRange(customTags);
-
-            return tagList.ToLegalStrings();
+            var tagList = new List<string>(LogglyConfig.Instance.TagConfig.Tags.Count + customTags.Count);
+            tagList.AddRange(LogglyConfig.Instance.TagConfig.Tags.ToLegalStrings());
+            tagList.AddRange(customTags.ToLegalStrings());
+            return tagList;
         }
     }
 }


### PR DESCRIPTION
Fixes legal tag checks where the '^' was allowed through, and length of 64 is required.

Improved memory efficiency by keeping one instance of the RegEx, and reducing number of list allocations.

Readability improvements to building message content, and removed memory allocation for single message case.