### PR TITLE
Avoid "Input string was not in a correct format." exception when searching

### DIFF
--- a/source/Loggly/LogglyException.cs
+++ b/source/Loggly/LogglyException.cs
@@ -25,16 +25,14 @@ namespace Loggly
         #endregion
 
         #region Static Methods
-        public static void Throw(string format, params object[] args)
+        public static void Throw(string message)
         {
-            string message = string.Format(format, args);
             var exception = new LogglyException(message);
             Throw(exception);
         }
 
-        public static void Throw(Exception innerException, string format, params object[] args)
+        public static void Throw(Exception innerException, string message)
         {
-            string message = string.Format(format, args);
             var exception = new LogglyException(message, innerException);
             Throw(exception);
         }


### PR DESCRIPTION
When using the search API, you could get exceptions such as

```
Message:Input string was not in a correct format.
StackTrace:   at Loggly.LogglyException.Throw(Exception innerException, String format, Object[] args)
   at Loggly.SearchTransport.Search[T](String endPoint, IDictionary`2 parameters)
```

This is because the responseBody of non HTTP 200 status code was passed into string.Format.

