### PR TITLE
Add netstandard20 nuget

### DIFF
--- a/source/Loggly.Config/Loggly.Config.nuspec
+++ b/source/Loggly.Config/Loggly.Config.nuspec
@@ -20,6 +20,7 @@
         <dependency id="System.Text.RegularExpressions" version="4.1.0" />
         <dependency id="System.Threading.Tasks" version="4.0.11" />
       </group>
+      <group targetFramework=".NETStandard2.0" />
     </dependencies>
   </metadata>
   <files>
@@ -27,5 +28,7 @@
     <file src="bin\$configuration$\Loggly.Config.pdb" target="lib\net45\" />
     <file src="..\NetStandard\Loggly.Config\bin\$configuration$\netstandard1.5\Loggly.Config.dll" target="lib\netstandard1.5" />
     <file src="..\NetStandard\Loggly.Config\bin\$configuration$\netstandard1.5\Loggly.Config.pdb" target="lib\netstandard1.5" />
+    <file src="..\NetStandard\Loggly.Config\bin\$configuration$\netstandard2.0\Loggly.Config.dll" target="lib\netstandard2.0" />
+    <file src="..\NetStandard\Loggly.Config\bin\$configuration$\netstandard2.0\Loggly.Config.pdb" target="lib\netstandard2.0" />
   </files>
 </package>

--- a/source/Loggly/Loggly.nuspec
+++ b/source/Loggly/Loggly.nuspec
@@ -27,6 +27,10 @@
                 <dependency id="loggly-csharp-config" version="$version$" />
                 <dependency id="Newtonsoft.Json" version="9.0.1" />
             </group>
+            <group targetFramework=".NETStandard2.0">
+                <dependency id="loggly-csharp-config" version="$version$" />
+                <dependency id="Newtonsoft.Json" version="9.0.1" />
+            </group>
         </dependencies>
     </metadata>
     <files>
@@ -34,5 +38,7 @@
         <file src="bin\$configuration$\Loggly.pdb" target="lib\net45\" />
         <file src="..\NetStandard\Loggly\bin\$configuration$\netstandard1.5\Loggly.dll" target="lib\netstandard1.5" />
         <file src="..\NetStandard\Loggly\bin\$configuration$\netstandard1.5\Loggly.pdb" target="lib\netstandard1.5" />
+        <file src="..\NetStandard\Loggly\bin\$configuration$\netstandard2.0\Loggly.dll" target="lib\netstandard2.0" />
+        <file src="..\NetStandard\Loggly\bin\$configuration$\netstandard2.0\Loggly.pdb" target="lib\netstandard2.0" />
     </files>
 </package>

--- a/source/NetStandard/Loggly.Config/Loggly.Config.csproj
+++ b/source/NetStandard/Loggly.Config/Loggly.Config.csproj
@@ -4,7 +4,7 @@
     <Description>Configuration classes for loggly clients. Settings are read from app.config or can be programmatically injected at runtime. See readme.md for documentation</Description>
     <AssemblyTitle>loggly-csharp-config</AssemblyTitle>
     <VersionPrefix>4.6.0</VersionPrefix>
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFrameworks>netstandard1.5;netstandard2.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);NET_STANDARD</DefineConstants>
     <AssemblyName>Loggly.Config</AssemblyName>
     <AssemblyOriginatorKeyFile>../../../LogglyCsharp.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
Some stuff was missing in order to get .NET Standard 2.0 build out on NuGet. Hopefully this will do it.