### PR TITLE
support ForwardedForIp property in transport object

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,9 @@ Uses Syslog over TCP but is not encrypted. Note this needs to be on port 514 for
 #### logTransport="SyslogSecure"
 Transmits using syslog messages via a secure TLS TCP channel so that your logs are encrypted over the wire. Syslog supports JSON formatted messages just like Https. Port 6514 is required for loggly and will be the default if not specified.
 
+#### ForwardedForIp
+When using remote logging from a desktop application, Loggly will record the IP of the machine transmitting logs (HTTP). This may represent PII (Personally Identifiable Information) and may not be desired. In order to override the value Loggly records, you may add the `ForwardedForIp` property to the Transport object's configuration with a dummy value (such as `0.0.0.0`). All messages sent to Loggly with record this Ip in the indexed clientHost property. The property allows for any string, but only a valid IP value will replace the indexed value at Loggly.
+
 #### tags 
 `simple` tags are string literals added to the app.config. What you see is what you get.
 

--- a/source/Loggly.Config/ConfigurationSection.csd
+++ b/source/Loggly.Config/ConfigurationSection.csd
@@ -134,6 +134,11 @@
             <externalTypeMoniker name="/d0ed9acb-0435-4532-afdd-b5115bc4d562/Boolean" />
           </type>
         </attributeProperty>
+        <attributeProperty name="ForwardedForIp" isRequired="false" isKey="false" isDefaultCollection="false" xmlName="forwardedForIp" isReadOnly="false">
+          <type>
+            <externalTypeMoniker name="/d0ed9acb-0435-4532-afdd-b5115bc4d562/String" />
+          </type>
+        </attributeProperty>
       </attributeProperties>
     </configurationElement>
     <configurationElement name="SearchAppConfig" accessModifier="Internal">

--- a/source/Loggly.Config/ConfigurationSection1.csd.cs
+++ b/source/Loggly.Config/ConfigurationSection1.csd.cs
@@ -920,7 +920,33 @@ namespace Loggly.Config
 				base[global::Loggly.Config.TransportAppConfig.IsOmitTimestampPropertyName] = value;
 			}
 		}
-		#endregion
+        #endregion
+
+        #region ForwardedForIp Property
+        /// <summary>
+        /// The XML name of the <see cref="ForwardedForIp"/> property.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ConfigurationSectionDesigner.CsdFileGenerator", "2.0.1.7")]
+        internal const string ForwardedForIpPropertyName = "forwardedForIp";
+
+        /// <summary>
+        /// Gets or sets the ForwardedForIp.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("ConfigurationSectionDesigner.CsdFileGenerator", "2.0.1.7")]
+        [global::System.ComponentModel.DescriptionAttribute("The ForwardedForIp.")]
+        [global::System.Configuration.ConfigurationPropertyAttribute(global::Loggly.Config.TransportAppConfig.ForwardedForIpPropertyName, IsRequired = false, IsKey = false, IsDefaultCollection = false)]
+        public virtual string ForwardedForIp
+        {
+            get
+            {
+                return ((string)(base[global::Loggly.Config.TransportAppConfig.ForwardedForIpPropertyName]));
+            }
+            set
+            {
+                base[global::Loggly.Config.TransportAppConfig.ForwardedForIpPropertyName] = value;
+            }
+        }
+        #endregion
     }
 }
 namespace Loggly.Config

--- a/source/Loggly.Config/ILogglyConfig.cs
+++ b/source/Loggly.Config/ILogglyConfig.cs
@@ -18,6 +18,7 @@ namespace Loggly.Config
         int EndpointPort { get; set; }
         LogTransport LogTransport { get; set; }
 		bool IsOmitTimestamp { get; set; }
+        string ForwardedForIp { get; set; }
     }
 
     public interface ISearchConfiguration

--- a/source/Loggly.Config/TransportConfiguration.cs
+++ b/source/Loggly.Config/TransportConfiguration.cs
@@ -9,10 +9,12 @@
         public int EndpointPort { get; set; }
 
 		public bool IsOmitTimestamp { get; set; }
+		
+        public string ForwardedForIp { get; set; }
 
         public override string ToString()
         {
-			return string.Format("LogTransport={0}, EndpointHostname={1}, EndpointPort={2}, IsOmitTimestamp={3}", LogTransport, EndpointHostname, EndpointPort, IsOmitTimestamp);
+			return string.Format("LogTransport={0}, EndpointHostname={1}, EndpointPort={2}, IsOmitTimestamp={3}, ForwardedForIp={4}", LogTransport, EndpointHostname, EndpointPort, IsOmitTimestamp, ForwardedForIp);
         }
     }
 }

--- a/source/Loggly/Transports/HttpTransports/HttpMessageTransport.cs
+++ b/source/Loggly/Transports/HttpTransports/HttpMessageTransport.cs
@@ -30,6 +30,11 @@ namespace Loggly
             HttpClient = new HttpClient(messageHandler);
             HttpClient.DefaultRequestHeaders.UserAgent.ParseAdd(_userAgent);
             HttpClient.DefaultRequestHeaders.Add("Connection", "close");
+
+            if (!string.IsNullOrWhiteSpace(LogglyConfig.Instance.Transport.ForwardedForIp))
+            {
+                HttpClient.DefaultRequestHeaders.Add("X-Forwarded-For", LogglyConfig.Instance.Transport.ForwardedForIp);
+            }
         }
 
         public HttpMessageTransport() : this(new HttpClientHandler())


### PR DESCRIPTION
There is a scenario where the loggly client is being used on desktop applications, and therefore the client's IP is being sent to loggly and indexed as clientHost. In some cases, this IP can be considered PII and undesired. By creating a new property on the transport object (ForwardedForIp), the requests made to loggly can contain a new IP (or value) to be sent and override the client's IP.

Previously to get something like this going, we were using an intermediate proxy, to route messages, so that loggly would have the proxy's IP. With this, we can opt in to override the value at the origin.

https://github.com/neutmute/loggly-csharp/pull/20 had support in a different manner for this property, but was removed once Loggly supported the header (but not necessarily this use case).