### PR TITLE
Reduce memory allocations when converting LogglyEvent to LogglyMessage

### DIFF
--- a/source/Loggly/Events/LogglyMessage.cs
+++ b/source/Loggly/Events/LogglyMessage.cs
@@ -1,9 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Net;
 using Loggly.Config;
-using Loggly.Responses;
-using Loggly.Transports.Syslog;
 
 namespace Loggly
 {
@@ -22,9 +19,14 @@ namespace Loggly
         public List<ITag> CustomTags { get; set; }
 
         public LogglyMessage()
+            :this(new List<ITag>(), new SyslogHeader())
         {
-            Syslog = new SyslogHeader();
-            CustomTags = new List<ITag>();
+        }
+
+        public LogglyMessage(List<ITag> customTags, SyslogHeader syslog)
+        {
+            CustomTags = customTags;
+            Syslog = syslog;
         }
 
         public override string ToString()

--- a/source/Loggly/Responses/LogResponse.cs
+++ b/source/Loggly/Responses/LogResponse.cs
@@ -4,21 +4,24 @@ namespace Loggly
 {
     public enum ResponseCode
     {
-        Unknown =0,
+        Unknown = 0,
         Success,
         Error,
         AssumedSuccess,
         SendDisabled
     }
-   public class LogResponse
-   {
-       public ResponseCode Code { get; set; }
+    public class LogResponse
+    {
+        public ResponseCode Code { get; set; }
 
-      public string Message { get; set; }
+        public string Message { get; set; }
 
-      public override string ToString()
-      {
-          return string.Format("Success={0}, Code={1}", Code, Message);
-      }
-   }
+        public override string ToString()
+        {
+            if (Code == ResponseCode.Success && string.IsNullOrEmpty(Message))
+                return "Success=Success, Code=";
+            else
+                return string.Format("Success={0}, Code={1}", Code, Message);
+        }
+    }
 }

--- a/source/Loggly/Transports/HttpTransports/HttpMessageTransport.cs
+++ b/source/Loggly/Transports/HttpTransports/HttpMessageTransport.cs
@@ -88,15 +88,17 @@ namespace Loggly
                     }
                 }
 
-                foreach (var m in list)
+                if (LogglyEventSource.Instance.IsEnabled())
                 {
-                    LogglyEventSource.Instance.Log(m, logResponse);
+                    foreach (var m in list)
+                    {
+                        LogglyEventSource.Instance.Log(m, logResponse);
+                    }
                 }
-
             }
             else
             {
-                logResponse = new LogResponse() { Code = ResponseCode.Unknown };
+                logResponse = new LogResponse() { Code = ResponseCode.Unknown, Message = "Loggly config missing or invalid" };
                 LogglyException.Throw("Loggly configuration is missing or invalid. Did you specify a customer token?");
             }
 
@@ -162,6 +164,8 @@ namespace Loggly
                 var tags = GetLegalTagUnion(messages[0].CustomTags);
                 if (tags.Count == 0)
                     return string.Empty;
+                else if (tags.Count == 1)
+                    return tags.First();
             }
 
             // if bulk sending messages, send all tags which have the same value for all messages


### PR DESCRIPTION
One might consider not having the conversion, but just have a single-object. But everything is public.